### PR TITLE
FIX: spatie/laravel-missing-page-redirector Error

### DIFF
--- a/src/Illuminate/Routing/Route.php
+++ b/src/Illuminate/Routing/Route.php
@@ -18,6 +18,7 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Traits\Macroable;
 use Laravel\SerializableClosure\SerializableClosure;
 use LogicException;
+use ReflectionFunction;
 use Symfony\Component\Routing\Route as SymfonyRoute;
 
 class Route
@@ -234,7 +235,9 @@ class Route
             $callable = unserialize($this->action['uses'])->getClosure();
         }
 
-        return $this->container[CallableDispatcher::class]->dispatch($this, $callable);
+        return $this->container[CallableDispatcher::class]->dispatch($this, $callable(...array_values($this->resolveMethodDependencies(
+            $this->parametersWithoutNulls(), new ReflectionFunction($callable)
+        ))));
     }
 
     /**


### PR DESCRIPTION
The package spatie/laravel-missing-page-redirector didn't work anymore after Laravel 9.32 update to 9.33

This should fix it.

